### PR TITLE
Move systemd logs to persistent storage

### DIFF
--- a/functions/system.bash
+++ b/functions/system.bash
@@ -207,6 +207,12 @@ misc_system_settings() {
   touch /home/"$username"/.ssh/authorized_keys
   chmod 600 /home/"$username"/.ssh/authorized_keys
   chown -R "$username:$username" /home/"$username"/.ssh
+  # By default, systemd logs are kept in volatile memory. Relocate to persistent memory to allow log rotation and archiving
+  echo "Creating persistent systemd journal folder location: /var/log/journal"
+  mkdir -p /var/log/journal
+  systemd-tmpfiles --create --prefix /var/log/journal
+  echo "Keeping at most 30 days of systemd journal entries"
+  journalctl --vacuum-time=30d
   # A distinguishable apt User-Agent
   echo "Acquire { http::User-Agent \"Debian APT-HTTP/1.3 openHABian\"; };" > /etc/apt/apt.conf.d/02useragent
   #


### PR DESCRIPTION
By default, the systemd journal files are stored in volatile memory.
In addition, the journal is never cleared.
As a result, unless rebooting, the journal can consume significant RAM.
The current patch addresses these issues.

Fixes #772

Signed-off-by: Olivier Biot <olivier.biot@gmail.com> (github: shutterfreak)